### PR TITLE
make it usable on additional platforms

### DIFF
--- a/terminal.go
+++ b/terminal.go
@@ -16,11 +16,7 @@ package goterm
 import (
 	"bytes"
 	"fmt"
-	"os"
-	"runtime"
 	"strings"
-	"syscall"
-	"unsafe"
 )
 
 // Reset all custom styles
@@ -61,31 +57,6 @@ type winsize struct {
 	Col    uint16
 	Xpixel uint16
 	Ypixel uint16
-}
-
-func getWinsize() (*winsize, error) {
-	ws := new(winsize)
-
-	var _TIOCGWINSZ int64
-
-	switch runtime.GOOS {
-	case "linux":
-		_TIOCGWINSZ = 0x5413
-	case "darwin":
-		_TIOCGWINSZ = 1074295912
-	}
-
-	r1, _, errno := syscall.Syscall(syscall.SYS_IOCTL,
-		uintptr(syscall.Stdin),
-		uintptr(_TIOCGWINSZ),
-		uintptr(unsafe.Pointer(ws)),
-	)
-
-	if int(r1) == -1 {
-		fmt.Println("Error:", os.NewSyscallError("GetWinsize", errno))
-		return nil, os.NewSyscallError("GetWinsize", errno)
-	}
-	return ws, nil
 }
 
 // Global screen buffer

--- a/terminal_nosysioctl.go
+++ b/terminal_nosysioctl.go
@@ -1,0 +1,12 @@
+// +build windows plan9 solaris
+
+package goterm
+
+func getWinsize() (*winsize, error) {
+	ws := new(winsize)
+
+	ws.Col = 80
+	ws.Row = 24
+
+	return ws, nil
+}

--- a/terminal_sysioctl.go
+++ b/terminal_sysioctl.go
@@ -1,0 +1,36 @@
+// +build !windows,!plan9,!solaris
+
+package goterm
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"syscall"
+	"unsafe"
+)
+
+func getWinsize() (*winsize, error) {
+	ws := new(winsize)
+
+	var _TIOCGWINSZ int64
+
+	switch runtime.GOOS {
+	case "linux":
+		_TIOCGWINSZ = 0x5413
+	case "darwin":
+		_TIOCGWINSZ = 1074295912
+	}
+
+	r1, _, errno := syscall.Syscall(syscall.SYS_IOCTL,
+		uintptr(syscall.Stdin),
+		uintptr(_TIOCGWINSZ),
+		uintptr(unsafe.Pointer(ws)),
+	)
+
+	if int(r1) == -1 {
+		fmt.Println("Error:", os.NewSyscallError("GetWinsize", errno))
+		return nil, os.NewSyscallError("GetWinsize", errno)
+	}
+	return ws, nil
+}


### PR DESCRIPTION
Platforms like plan9, windows and solaris don't support SYS_IOCTL.

This change will default to a terminal size of **80x24** on these platforms and circumvent the missing feature.
