### PR TITLE
Add executable examples and optional IO output

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ func main() {
 }
 ```
 
+This can be seen in [examples/time_example.go](examples/time_example.go).  To
+run it yourself, go into your `$GOPATH/src/github.com/buger/goterm` directory
+and run `go run ./examples/time_example.go`
+
 
 Print red bold message on white background:
 
@@ -44,8 +48,10 @@ tm.Println(tm.Backgound(tm.Color(tm.Bold("Important header"), tm.RED), tm.WHITE)
 Create box and move it to center of the screen:
 
 ```go
+tm.Clear()
+
 // Create Box with 30% width of current screen, and height of 20 lines
-box := tm.NewBox(30|tm.PCT, 20)
+box := tm.NewBox(30|tm.PCT, 20, 0)
 
 // Add some content to the box
 // Note that you can add ANY content, even tables
@@ -53,8 +59,11 @@ fmt.Fprint(box, "Some box content")
 
 // Move Box to approx center of the screen
 tm.Print(tm.MoveTo(box.String(), 40|tm.PCT, 40|tm.PCT))
+
+tm.Flush()
 ```
 
+This can be found in [examples/box_example.go](examples/box_example.go).
 
 Draw table:
 
@@ -64,7 +73,10 @@ totals := tm.NewTable(0, 10, 5, ' ', 0)
 fmt.Fprintf(totals, "Time\tStarted\tActive\tFinished\n")
 fmt.Fprintf(totals, "%s\t%d\t%d\t%d\n", "All", started, started-finished, finished)
 tm.Println(totals)
+tm.Flush()
 ```
+
+This can be found in [examples/table_example.go](examples/table_example.go).
 
 ## Line charts
 
@@ -92,6 +104,7 @@ Chart example:
     tm.Println(chart.Draw(data))
 ```
 
+This can be found in [examples/chart_example.go](examples/chart_example.go).
 
 Drawing 2 separate graphs in different scales. Each graph have its own Y axe.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Full API documentation: http://godoc.org/github.com/buger/goterm
 
 ## Basic usage
 
-Full screen console app, priting current time:
+Full screen console app, printing current time:
 
 ```go
 import (

--- a/examples/box_example.go
+++ b/examples/box_example.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+	tm "github.com/buger/goterm"
+)
+
+func main() {
+	tm.Clear()
+
+	// Create Box with 30% width of current screen, and height of 20 lines
+	box := tm.NewBox(30|tm.PCT, 20, 0)
+
+	// Add some content to the box
+	// Note that you can add ANY content, even tables
+	fmt.Fprint(box, "Some box content")
+
+	// Move Box to approx center of the screen
+	tm.Print(tm.MoveTo(box.String(), 40|tm.PCT, 40|tm.PCT))
+
+	tm.Flush()
+}

--- a/examples/chart_example.go
+++ b/examples/chart_example.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	tm "github.com/buger/goterm"
+	"math"
+)
+
+func main() {
+	tm.Clear()
+	tm.MoveCursor(0, 0)
+
+	chart := tm.NewLineChart(100, 20)
+	data := new(tm.DataTable)
+	data.AddColumn("Time")
+	data.AddColumn("Sin(x)")
+	data.AddColumn("Cos(x+1)")
+
+	for i := 0.1; i < 10; i += 0.1 {
+		data.AddRow(i, math.Sin(i), math.Cos(i+1))
+	}
+
+	tm.Println(chart.Draw(data))
+	tm.Flush()
+}

--- a/examples/file_output_example.go
+++ b/examples/file_output_example.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	tm "github.com/buger/goterm"
+	"os"
+)
+
+func main() {
+	f, err := os.Create("box.txt")
+	if err != nil {
+		panic("Unable to create box file!")
+	}
+	defer f.Close()
+
+	// Tell tm to use the file we just opened, not stdout
+	tm.Output = bufio.NewWriter(f)
+
+	// More or less stolen from the box example
+	tm.Clear()
+	box := tm.NewBox(30|tm.PCT, 20, 0)
+	fmt.Fprint(box, "Some box content")
+	tm.Print(tm.MoveTo(box.String(), 40|tm.PCT, 40|tm.PCT))
+	tm.Flush()
+
+	fmt.Println("Now view the contents of 'box.txt' in an ansi-capable terminal")
+}

--- a/examples/table_example.go
+++ b/examples/table_example.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	tm "github.com/buger/goterm"
+)
+
+func main() {
+	tm.Clear() // Clear current screen
+	started := 100
+	finished := 250
+
+	// Based on http://golang.org/pkg/text/tabwriter
+	totals := tm.NewTable(0, 10, 5, ' ', 0)
+	fmt.Fprintf(totals, "Time\tStarted\tActive\tFinished\n")
+	fmt.Fprintf(totals, "%s\t%d\t%d\t%d\n", "All", started, started-finished, finished)
+	tm.Println(totals)
+
+	tm.Flush()
+}

--- a/examples/time_example.go
+++ b/examples/time_example.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	tm "github.com/buger/goterm"
+	"time"
+)
+
+func main() {
+	tm.Clear() // Clear current screen
+
+	for {
+		// By moving cursor to top-left position we ensure that console output
+		// will be overwritten each time, instead of adding new.
+		tm.MoveCursor(1, 1)
+
+		tm.Println("Current Time:", time.Now().Format(time.RFC1123))
+
+		tm.Flush() // Call it every time at the end of rendering
+
+		time.Sleep(time.Second)
+	}
+}

--- a/terminal.go
+++ b/terminal.go
@@ -14,8 +14,10 @@
 package goterm
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
+	"os"
 	"strings"
 )
 
@@ -36,6 +38,8 @@ const (
 	CYAN
 	WHITE
 )
+
+var Output *bufio.Writer = bufio.NewWriter(os.Stdout)
 
 func getColor(code int) string {
 	return fmt.Sprintf("\033[3%dm", code)
@@ -100,7 +104,7 @@ func applyTransform(str string, transform sf) (out string) {
 
 // Clear screen
 func Clear() {
-	fmt.Print("\033[2J")
+	Output.WriteString("\033[2J")
 }
 
 // Move cursor to given position
@@ -176,9 +180,10 @@ func Flush() {
 			return
 		}
 
-		fmt.Println(str)
+		Output.WriteString(str + "\n")
 	}
 
+	Output.Flush()
 	Screen.Reset()
 }
 


### PR DESCRIPTION
Adds several examples pulled partly from the readme, fixes the readme to document the examples a bit better (some incorrect code was fixed), and adds an accessible property to allow a custom bufio.Writer, which defaults to just wrapping stdout.