### PR TITLE
terminal: fix 32 bit build

### DIFF
--- a/terminal.go
+++ b/terminal.go
@@ -54,7 +54,8 @@ func getBgColor(code int) string {
 // Check percent flag: num & PCT
 //
 // Reset percent flag: num & 0xFF
-const PCT = 0x80000000
+const shift = uint(^uint(0)>>63) << 4
+const PCT = 0x8000 << shift
 
 type winsize struct {
 	Row    uint16


### PR DESCRIPTION
I was trying to use vctl which uses this library on a 32 bit machine
(Linux 3.14.0 armv7l) and failed to build.

    ../../buger/goterm/terminal.go:81: constant 2147483648 overflows int
    ../../buger/goterm/terminal.go:85: constant 2147483648 overflows int

This will cut the constant in half on 32 bit systems. I don't know if
this is right but it seemed to work. Happy to fix up the patch further,
I just don't understand what PCT is for.