### PR TITLE
Fix boundaries computation

### DIFF
--- a/plot.go
+++ b/plot.go
@@ -242,10 +242,10 @@ func (c *LineChart) DrawLine(x0, y0, x1, y1 int, symbol string) {
 }
 
 func getBoundaryValues(data *DataTable, index int) (maxX, minX, maxY, minY float64) {
-	maxX = data.rows[0][0]
-	minX = data.rows[0][0]
-	maxY = data.rows[0][1]
-	minY = data.rows[0][1]
+	maxX = math.Inf(-1)
+	minX = math.Inf(1)
+	maxY = math.Inf(-1)
+	minY = math.Inf(1)
 
 	for _, r := range data.rows {
 		maxX = math.Max(maxX, r[0])

--- a/plot_test.go
+++ b/plot_test.go
@@ -38,19 +38,33 @@ func TestLineChartIndependent(t *testing.T) {
 
 	chart := NewLineChart(100, 20)
 	chart.Flags = DRAW_INDEPENDENT //| DRAW_RELATIVE
+	chartReversed := NewLineChart(100, 20)
+	chartReversed.Flags = DRAW_INDEPENDENT
 
 	data := new(DataTable)
 	data.AddColumn("Time")
 	data.AddColumn("Lat")
 	data.AddColumn("Count")
 
+	dataReversed := new(DataTable)
+	dataReversed.AddColumn("Time")
+	dataReversed.AddColumn("Lat")
+	dataReversed.AddColumn("Count")
+
 	//data.AddColumn("x*x")
 
 	for i := 0; i < 60; i++ {
-		data.AddRow(float64(i+60), float64(20+rand.Intn(10)), float64(i*2+rand.Intn(i+1))) // ,*/, x*x)
+		x := float64(i + 60)
+		y1 := float64(20 + rand.Intn(10))
+		y2 := float64((60-i)*2 + rand.Intn((60-i)+1))
+
+		data.AddRow(x, y1, y2) // ,*/, x*x)
+		dataReversed.AddRow(x, y2, y1)
 	}
 
+	// The two charts should look the same, only with inversed axes and colors
 	fmt.Println(chart.Draw(data))
+	fmt.Println(chartReversed.Draw(dataReversed))
 }
 
 func TestLineChartRelative(t *testing.T) {


### PR DESCRIPTION
If an index different than 1 was provided the Y max/min could be wrong.
This happened in the case where the first Y value of the index 1 was
greater/slower than any other value.

As an example of this I modified the tests to show two charts that should appear the same (except for reversed axes and colors) but did not.