### PR TITLE
Fix ResetLine by using string formatting

### DIFF
--- a/terminal.go
+++ b/terminal.go
@@ -148,7 +148,7 @@ func MoveTo(str string, x int, y int) (out string) {
 // Return carrier to start of line
 func ResetLine(str string) (out string) {
 	return applyTransform(str, func(idx int, line string) string {
-		return fmt.Sprintf(RESET_LINE, line)
+		return fmt.Sprintf("%s%s", RESET_LINE, line)
 	})
 }
 


### PR DESCRIPTION
Hi! It looks like `ResetLine` wasn't working as expected. See this example code:

```go
package main

import (
  "github.com/buger/goterm"
)

func main() {
  goterm.Println("First Line")
  goterm.Flush()
  goterm.MoveCursorUp(2)
  goterm.Println(goterm.ResetLine("Second Line"))
  goterm.Flush()
}
```

The expected output is: `Second Line` but instead the output is `%!(EXTRA string=Second Line)` since the `Sprintf` looks incorrect in `ResetLine`.