### PR TITLE
Remove concatenation of "\n" in Flush()

### DIFF
--- a/terminal.go
+++ b/terminal.go
@@ -215,12 +215,12 @@ func CurrentHeight() int {
 
 // Flush buffer and ensure that it will not overflow screen
 func Flush() {
-	for idx, str := range strings.Split(Screen.String(), "\n") {
+	for idx, str := range strings.SplitAfter(Screen.String(), "\n") {
 		if idx > Height() {
 			return
 		}
 
-		Output.WriteString(str + "\n")
+		Output.WriteString(str)
 	}
 
 	Output.Flush()


### PR DESCRIPTION
This concatenation breaks the purpose of using multiple Print() or
Printf() to print strings in the same line if Flush() is called between
them.

Suggested by @whrool
Fixes #13

Signed-off-by: Éverton Arruda <root@earruda.eti.br>