### PR TITLE
Fix  "get Winsize redeclared in this block" due to platform build directives

### DIFF
--- a/terminal_nosysioctl.go
+++ b/terminal_nosysioctl.go
@@ -1,4 +1,4 @@
-// +build !windows plan9 solaris
+// +build plan9 solaris
 
 package goterm
 


### PR DESCRIPTION
While using last master version, ran into this on linux. 
(Due to the added terminal_windows.go file)
tested the forked version of this PR on windows & linux, fixed, cf used lib [here](https://github.com/docker/compose-cli/pull/1488)

Signed-off-by: Guillaume Tardif <guillaume.tardif@gmail.com>