### PR TITLE
fix: change Height() to return math.MaxInt if we could not retrieve t…

### DIFF
--- a/terminal.go
+++ b/terminal.go
@@ -16,9 +16,13 @@ package goterm
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
+	"math"
 	"os"
 	"strings"
+
+	"golang.org/x/sys/unix"
 )
 
 // Reset all custom styles
@@ -203,6 +207,11 @@ func Width() int {
 func Height() int {
 	ws, err := getWinsize()
 	if err != nil {
+		// returns math.MaxInt if we could not retrieve the height of console window,
+		// like VSCode debugging console
+		if errors.Is(err, unix.EOPNOTSUPP) {
+			return math.MaxInt
+		}
 		return -1
 	}
 	return int(ws.Row)


### PR DESCRIPTION
change `func Height() int` to return math.MaxInt when we could not retrieve the height of console window, otherwise nothing will be printed. 

Like in VSCode debugging console.